### PR TITLE
Makes _ optional in =let* and reindents code.

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -13,12 +13,12 @@
   (:method ((input cl:string))
     (declare (optimize (speed 3)))
     (multiple-value-bind (string index)
-	(array-displacement input)
+        (array-displacement input)
       (let ((original-string (or string input)))
-    (make-array (1- (length input))
-		:displaced-to original-string
-		:displaced-index-offset (1+ index)
-		:element-type 'character)))))
+        (make-array (1- (length input))
+                    :displaced-to original-string
+                    :displaced-index-offset (1+ index)
+                    :element-type 'character)))))
 
 (defgeneric input-error (input message &rest args)
   (:method (input message &rest args) (error message args)))
@@ -34,7 +34,7 @@
 
 (defmethod input-rest (input) 
   (%make-file-input :stream (file-stream-input-stream input)
-		    :file-position (1+ (file-stream-input-file-position input))))
+                    :file-position (1+ (file-stream-input-file-position input))))
 
 (defmethod input-empty-p (input)
   (= (file-stream-input-file-position input) (file-length (file-stream-input-stream input))))
@@ -44,11 +44,11 @@
 
 (defmethod input-error ((input file-stream-input) message &rest args)
   (error 'input-error 
-	 :input input
-	 :format-control "Error at ~A : ~A" 
-	 :format-arguments (list (file-stream-input-file-position input) 
-				 (apply #'format nil message args))))
-  
+         :input input
+         :format-control "Error at ~A : ~A" 
+         :format-arguments (list (file-stream-input-file-position input) 
+                                 (apply #'format nil message args))))
+
 (defstruct (line-input (:constructor %make-line-input)) 
   string (index 0) (line-count 1))
 
@@ -61,30 +61,29 @@
 
 (defmethod input-first ((input line-input))
   (aref (line-input-string input) 
-       (line-input-index input)))
+        (line-input-index input)))
 
 (defmethod input-rest  ((input line-input))
   (%make-line-input :index (1+ (line-input-index input))
-		    :string (line-input-string input)
-		    :line-count (line-input-line-count input)))
+                    :string (line-input-string input)
+                    :line-count (line-input-line-count input)))
 
 (define-condition input-error (simple-error) ((input :accessor input-error-input :initarg :input)))
 
 (defmethod input-error ((input line-input) message &rest args)
   (error 'input-error 
-	 :input input
-	 :format-control "Error on line ~A : ~A" 
-	 :format-arguments (list (line-input-line-count input) (apply #'format nil message args))))
+         :input input
+         :format-control "Error on line ~A : ~A" 
+         :format-arguments (list (line-input-line-count input) (apply #'format nil message args))))
 
 (defun fail (&key (error nil))
   (if error 
       (lambda (input)
-	(input-error input error)
-	(funcall (result t) input))
+        (input-error input error)
+        (funcall (result t) input))
       (constantly nil)))
-	 
+
 (defun increment-line-count (&optional (delta 1))
   (lambda (input) 
     (funcall (result (incf (line-input-line-count input) delta))
-	     input)))
-
+             input)))

--- a/package.lisp
+++ b/package.lisp
@@ -49,4 +49,3 @@
 
 (defpackage :smug.examples 
   (:use :cl :smug))
-

--- a/smug.asd
+++ b/smug.asd
@@ -3,6 +3,5 @@
 (asdf:defsystem #:smug
   :serial t
   :components ((:file "package")
-	       (:file "input")
+               (:file "input")
                (:file "smug")))
-

--- a/smug.lisp
+++ b/smug.lisp
@@ -8,46 +8,49 @@
 (defun fail (&key (error nil))
   (if error 
       (lambda (input)
-	(declare (ignore input)) 
-	(error error))
+        (declare (ignore input)) 
+        (error error))
       (constantly nil)))
 
 (defun item ()
   (lambda (input)
     (unless (input-empty-p input)
       (list (cons (input-first input)
-		  (input-rest input))))))
+                  (input-rest input))))))
 
 (defun bind (parser function)
   (lambda (input)
     (loop :for (value . input) :in (funcall parser input)
-          :append (funcall (funcall function value) input))))
+       :append (funcall (funcall function value) input))))
 
 (defun run (parser input &key (result #'caar))
   (funcall result (funcall parser input)))
 
 (defun =satisfies (predicate)
   (bind (item) 
-	(lambda (x) 
-	  (if (funcall predicate x)
-	      (result x)
-	      (fail)))))
+        (lambda (x) 
+          (if (funcall predicate x)
+              (result x)
+              (fail)))))
 
 (defun plus (&rest parsers)
   (lambda (input)
     (loop :for parser in parsers 
-          :append (funcall parser input))))
+       :append (funcall parser input))))
 
 ;;;; PARSER-LET* is the natural syntax for lispers
 (defmacro =let* (bindings &body body)
   (if bindings
       (let ((symbol (first (first bindings))))
-	`(bind ,@(cdr (first bindings))
-	       (lambda (,symbol)
-		 ,@(when (string-equal (symbol-name symbol) "_")
-			 `((declare (ignorable ,symbol))))
-	       (=let* ,(cdr bindings)
-		 ,@body))))
+        (when (listp symbol)
+          (setf bindings (cons (list '_ symbol) (cdr bindings))
+                symbol '_))
+        `(bind ,@(cdr (first bindings))
+               (lambda (,symbol)
+                 ,@(when (string-equal (symbol-name symbol) "_")
+                         `((declare (ignorable ,symbol))))
+                 (=let* ,(cdr bindings)
+                   ,@body))))
       `(progn ,@body)))
 
 (defun end-of-input ()
@@ -59,17 +62,17 @@
 (defun =or (&rest parsers)
   (declare (optimize (speed 3)))
   (labels ((non-consing-or (parsers)
-	   (lambda (input)
-	     (or (funcall (the function (first parsers)) input) 
-		 (when (rest parsers)
-		   (funcall (the function (non-consing-or (rest parsers))) input))))))
+             (lambda (input)
+               (or (funcall (the function (first parsers)) input) 
+                   (when (rest parsers)
+                     (funcall (the function (non-consing-or (rest parsers))) input))))))
     (non-consing-or parsers)))
 
 (defun =and (p1 &rest ps)
   (=let* ((result p1))
     (if ps
-	(apply #'=and ps)
-	(result result))))    
+        (apply #'=and ps)
+        (result result))))    
 
 (defun =not (parser)
   (lambda (input)
@@ -84,43 +87,43 @@
 
 (defun before (parser end-parser)
   (=let* ((i parser)
-	  (result (lambda (input)
-		    (if (funcall end-parser input)
-			(list (cons i input))
-			nil))))
+          (result (lambda (input)
+                    (if (funcall end-parser input)
+                        (list (cons i input))
+                        nil))))
     (result result)))
 
 (defun =string (string)
   (if (input-empty-p string)
       (result "")
       (=let* 
-	  ((_ (=char (input-first string)))
-	   (_ (=string (input-rest string))))
-	(result string))))
+          ((_ (=char (input-first string)))
+           ((=string (input-rest string))))
+        (result string))))
 
 (defun =digit-char (&optional (base 10))
   (=satisfies (lambda (x) (digit-char-p x base))))
 
 (defun digit ()
   (=let* ((char (item))
-	  (digit (result (digit-char-p char))))
+          (digit (result (digit-char-p char))))
     (if digit (result digit) (fail))))
 
 (defun natural-number (&optional (base 10))
   (labels ((evaluate (chars)
-	     (reduce #'op (mapcar (lambda (c) (digit-char-p c base)) chars)))
-	   (op (m n)
-	     (+ (* base m) n)))
+             (reduce #'op (mapcar (lambda (c) (digit-char-p c base)) chars)))
+           (op (m n)
+             (+ (* base m) n)))
     (=let* ((xs (one-or-more (=digit-char base))))
       (result (evaluate xs)))))
 
 (defun sophisticated-int ()
   (flet ((op () 
-	   (plus (=let* ((_ (=char #\-)))
-		   (result #'-))
-		 (result #'identity))))
+           (plus (=let* ((_ (=char #\-)))
+                   (result #'-))
+                 (result #'identity))))
     (=let* ((op (op))
-		  (n (natural-number)))
+            (n (natural-number)))
       (result (funcall op n)))))
 
 (defun int ()
@@ -128,21 +131,21 @@
 
 (defun bracket (open-parser body-parser close-parser)
   (=let* ((_ open-parser)
-	       (x body-parser)
-	       (_ close-parser))
+          (x body-parser)
+          (_ close-parser))
     (result x)))
 
 (defun none-of (char-bag)
   (=let* ((char (item)))
     (if (not (find char char-bag))
-	(result char)
-	(fail))))
+        (result char)
+        (fail))))
 
 (defun one-of (char-bag)
   (=let* ((char (item)))
     (if (find char char-bag)
-	(result char)
-	(fail))))    
+        (result char)
+        (fail))))    
 
 (defun text (&optional (parser (item)))
   (=let* ((text (one-or-more parser)))
@@ -150,39 +153,39 @@
 
 (defun eof (&optional (result :eof))
   (bind (end-of-input) 
-	(lambda (_) (declare (ignore _ )) 
-		(result result))))
+        (lambda (_) (declare (ignore _ )) 
+                (result result))))
 
 (defun zero-or-more-recursive (parser &optional (combinator #'=or))
   (funcall (the function combinator)
-   (=let* ((x (the function parser))
-	   (y (=or (zero-or-more-recursive parser combinator)
-		   (result nil))))
-     (result (cons x y)))
-   (result nil)))
+           (=let* ((x (the function parser))
+                   (y (=or (zero-or-more-recursive parser combinator)
+                           (result nil))))
+             (result (cons x y)))
+           (result nil)))
 
 (defun zero-or-more (parser)
   (lambda (input) :result #'identity
-    (loop 
-       :for value := (funcall parser input)
-       :for ((result . i)) := value
-       :while value :collect result :into results 
-       :do (setf input i)				     
-       :finally (return (list (cons results input))))))
+          (loop 
+             :for value := (funcall parser input)
+             :for ((result . i)) := value
+             :while value :collect result :into results 
+             :do (setf input i)				     
+             :finally (return (list (cons results input))))))
 
 
 (defun one-or-more (parser)
   (=let* ((x parser)
-	  (y (zero-or-more parser)))
+          (y (zero-or-more parser)))
     (result (cons x y))))
 
 (defun one-to (n parser)
   (case n
     (0 (result nil))
     (t (=let* ((x parser)
-	       (xs (=or (one-to (1- n) parser)
-			(result nil))))
-	 (result (cons x xs))))))
+               (xs (=or (one-to (1- n) parser)
+                        (result nil))))
+         (result (cons x xs))))))
 
 (defun zero-to (n parser)
   (maybe (one-to n parser)))
@@ -191,35 +194,35 @@
 (defun at-least (n parser &key limit)
   (case n 
     (0 (if limit 
-	   (if (zerop limit)
-	       (result nil)
-	       (zero-to limit parser))
-	   (zero-or-more parser)))
+           (if (zerop limit)
+               (result nil)
+               (zero-to limit parser))
+           (zero-or-more parser)))
     (t (=let* ((x parser)
-	       (xs (at-least (1- n) parser :limit (1- limit))))
-	 (result (cons x xs))))))
+               (xs (at-least (1- n) parser :limit (1- limit))))
+         (result (cons x xs))))))
 
 (defun exactly (n parser)
   (at-least n parser :limit n))
-	 
-    
+
+
 (defun line ()
   (=or 
    (=let* ((xs (text (none-of '(#\Newline))))
-	   (end (=or (end-of-input) 
-		     (=char #\Newline))))       
+           (end (=or (end-of-input) 
+                     (=char #\Newline))))       
      (result 
       (list* :line xs (list end))))
    (bind (=char #\Newline) 
-	 (constantly 
-	  (result '(:line "" :terminator #\Newline))))))
+         (constantly 
+          (result '(:line "" :terminator #\Newline))))))
 
 (defun =progn (&rest parsers)
   (apply #'=and parsers))
 
 (defun =prog1 (parser &rest parsers)
   (=let* ((result parser)
-	  (_ (apply #'=and parsers)))
+          (_ (apply #'=and parsers)))
     (result result)))
 
 (defun =prog2 (parser1 parser2 &rest parsers)
@@ -234,18 +237,18 @@
 (defun =list (&rest parsers)
   (if parsers 
       (=let* ((x (first parsers))
-	      (xs (apply '=list (rest parsers))))
-	(result (cons x xs)))
+              (xs (apply '=list (rest parsers))))
+        (result (cons x xs)))
       (result nil)))
 
 (defun call (function-designator &rest args)
   (result (apply function-designator args)))
-	      
+
 
 (defun skip-whitespace (parser)
   (=let* ((_ (zero-or-more (whitespace)))
-	  (v parser)
-	  (_ (zero-or-more (whitespace))))
+          (v parser)
+          (_ (zero-or-more (whitespace))))
     (result v)))
 
 (defun maybe (parser)
@@ -254,9 +257,9 @@
 (defun range (from to &key (parser (item)) (predicate 'char<=))
   (=let* ((char parser))
     (if (funcall predicate from char to)
-	(result char) 
-	(fail))))
-	
+        (result char) 
+        (fail))))
+
 (defun org-block (&optional (level 0))
   (=or (section level)
        (simple-list)
@@ -264,90 +267,48 @@
 
 (defun text-block (parser)
   (=and (=not (section-heading))
-	parser))
+        parser))
 
 (defun section-heading (&optional (level 0))
   (=let* ((indicator (at-least (1+ level)
-			       (=char #\*)))   
-	  (space (one-or-more (=char #\Space)))
-	  (name (line)))
+                               (=char #\*)))   
+          (space (one-or-more (=char #\Space)))
+          (name (line)))
     (result (list :level (length indicator) 
-		  :indicator (cons indicator space)
-		  :name name))))
+                  :indicator (cons indicator space)
+                  :name name))))
 
 (defun section (&optional (level 0))
   (=let* ((heading (section-heading level))
-	  (contents (zero-or-more 
-		     (org-block (1+ level)))))
+          (contents (zero-or-more 
+                     (org-block (1+ level)))))
     (result (list :section :heading heading :contents contents))))
-	
+
 (defun section-line (&optional (level 0))
   (=and (=not (section-heading level))
-	      (line)))
+        (line)))
 
 (defun list-item-content-line (indentation-level)
   (=let* ((indentation (at-least indentation-level (whitespace)))
-	  (line (line)))
+          (line (line)))
     (result (cons indentation line))))
-	
+
 (defun list-item ()
   (=let* ((pre-space (zero-or-more (whitespace)))
-	  (indicator (one-of "*+-"))
-	  (post-space (one-or-more (whitespace)))
-	  (first-line (line))
-	  (rest-lines (zero-or-more 
-		       (list-item-content-line 
-			(+ 1 (length pre-space)
-			     (length post-space))))))
+          (indicator (one-of "*+-"))
+          (post-space (one-or-more (whitespace)))
+          (first-line (line))
+          (rest-lines (zero-or-more 
+                       (list-item-content-line 
+                        (+ 1 (length pre-space)
+                           (length post-space))))))
     (result (list :list-item
-		  :indicator (list pre-space
-				    indicator
-				    post-space)
-		  :content (cons (cons nil first-line) 
-				 rest-lines)))))
-    
+                  :indicator (list pre-space
+                                   indicator
+                                   post-space)
+                  :content (cons (cons nil first-line) 
+                                 rest-lines)))))
+
 (defun simple-list ()
   (=let* ((list (text-block (one-or-more (list-item)))))
     (result (cons :unordered-list list))))
-
-
-
-
-
-    
-	
-		
-
-
-
-
-
-	      
-
-
-
-
-
-
-
-    
-
-
-
- 
-	
- 
-      
-     
-
-
-	      
-
-
-			 	  
-  
-
-
-
-
-

--- a/smug.org
+++ b/smug.org
@@ -539,7 +539,7 @@ do
        (pointed-gun (point-gun-at-bad-guy gun))
        (fired-gun (pull-trigger pointed-gun)))
   (identity fired-gun))
-#+BEGIN_SRC
+#+END_SRC
 
   One could legitimately say that the common lisp package is an
   instance of the identity monad, if one cared for such insights.
@@ -550,18 +550,23 @@ do
     advantage of the monadic nature of parsers. It's often useful to
     ignore a value. In haskell, the underscore character is used to
     denote an ignorable variable, so we'll use the same convention.
+    As a convenience, the underscore may be omitted. 
 
 #+BEGIN_SRC lisp
 (defmacro =let* (bindings &body body)
   (if bindings
       (let ((symbol (first (first bindings))))
-	`(bind ,@(cdr (first bindings))
-	       (lambda (,symbol)
-		 ,@(when (string-equal (symbol-name symbol) "_")
-			 `((declare (ignorable ,symbol))))
-		 (=let* ,(cdr bindings)
-		   ,@body))))
+        (when (listp symbol)
+          (setf bindings (cons (list '_ symbol) (cdr bindings))
+                symbol '_))
+        `(bind ,@(cdr (first bindings))
+               (lambda (,symbol)
+                 ,@(when (string-equal (symbol-name symbol) "_")
+                         `((declare (ignorable ,symbol))))
+                 (=let* ,(cdr bindings)
+                        ,@body))))
       `(progn ,@body)))
+
 #+END_SRC
 
 If we replace BIND with our I-BIND function above, we get a macro that
@@ -579,7 +584,7 @@ much nicer way to work than nesting BINDs.
       (result "")
       (=let* 
 	  ((_ (=char (input-first string)))
-	   (_ (=string (input-rest string))))
+	   ((=string (input-rest string))))
 	(result string))))
 
 (funcall (=string "asdf")  "asdfjkl") => (("asdf" . "jkl"))
@@ -796,13 +801,3 @@ Nottingham, 1996. http://www.cs.nott.ac.uk/~gmh/bib.html#monparsing
 
 
 #(end-lisp)
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
``` lisp
(=let* (((foo))
       (var (bar))
       ((baz)))
  ...)
```

is now a supported synonym for:

``` lisp
(=let* ((_ (foo))
       (var (bar))
       (_ (baz)))
  ...)
```

This change makes `=let*` function more like Haskell's do-notation.

The code is reindented using Emacs's default settings (Note:
indent-tabs-mode was nil, the tab width was 4 spaces, and Slime was
loaded along with smug).

The documentation is updated to reflect the changes in this commit.
Also, an improperly-closed SRC block is now closed.

Spurious blank lines at the end of source files are removed.
