### PR TITLE
Make the restart work correctly.

### DIFF
--- a/smug.lisp
+++ b/smug.lisp
@@ -48,27 +48,32 @@
                    ,@body))))
       `(progn ,@body)))
 
-(defun replace-subseq (needle haystack replacement)
-  (let* ((haystack (copy-seq haystack))
-         (idx (search needle haystack :test 'equal)))
-    (when idx
-      (replace haystack replacement :start1 idx))
-    haystack))
+(defun replace-beginning (needle haystack replacement)
+  (let* ((needle-length (length needle)))
+    (if (string= haystack needle :end1 needle-length)
+      (concatenate 'string
+                   replacement
+                   (subseq haystack needle-length))
+      haystack)))
 
-(defun replace-invalid (old new)
+(defun replace-invalid (old new &optional was-equal)
   (let ((replace-invalid (find-restart 'replace-invalid)))
     (when replace-invalid
-      (invoke-restart replace-invalid old new))))
+      (invoke-restart replace-invalid old new was-equal))))
 
 (defun run (parser input)
+  (declare (optimize (debug 3)))
+  (loop
     (restart-case
-      (progn
-        (funcall parser input))
-      (replace-invalid (old new)
-         (let ((next-replace-invalid (find-restart 'replace-invalid)))
-           (if (and next-replace-invalid (not (search old input)))
-             (invoke-restart 'replace-invalid old new)
-             (funcall parser (replace-subseq old (copy-seq input) new)))))))
+      (return (funcall parser input))
+        
+      (replace-invalid (old new &optional was-equal)
+        (let* ((old-length (length old))
+               (begins-with (and (<= old-length (length input))
+                                 (string= old input :end2 old-length))))
+          (if (and begins-with was-equal)
+            (setf input (replace-beginning old input new))        
+            (replace-invalid old new begins-with)))))))
 
 (defun parse (parser input)
   (let ((result (run parser input)))


### PR DESCRIPTION
When the restart is active, it can be triggered via the (replace-invalid) function.  For this to work, the parser that throws the error cannot be being run directly, but must be called by another parser.  When the restart is triggered, it unwinds the parser stack one parser higher than the parser that signaled the condition and then fixes its input and reruns it.

This fixes a couple errors in the last pull request.  However, there's a slight difficulty with the current pull-request: when #'run is called on a parser that raises an exception, invoking the restart will often lead to a loop because, once the replacement is made, it is fed back into the parser and tested again: if all a parser does is raise an exception, this will cause an infinite loop.