### PR TITLE
Update tutorial.org

### DIFF
--- a/doc/tutorial.org
+++ b/doc/tutorial.org
@@ -182,7 +182,7 @@
 
 ** ~.ITEM~
 
-    The last true primitive is .~.ITEM~, which is a parser that
+    The last true primitive is ~.ITEM~, which is a parser that
     consumes the first token in the input, or fails in the input is
     empty.
 


### PR DESCRIPTION
The word "item" wasn't getting parsed by GitHub's version of org.